### PR TITLE
Fix dead neptune.ai blog link in manual

### DIFF
--- a/doc/source/written/manual.md
+++ b/doc/source/written/manual.md
@@ -1735,7 +1735,7 @@ https://hydra.cc/ |*||
 See also [this long list of workflow
 engines](https://github.com/meirwah/awesome-workflow-engines) and [this even
 longer list of MLOps
-tools](https://neptune.ai/blog/mlops-tools-platforms-landscape).
+tools](https://web.archive.org/web/20251006160541/https://neptune.ai/blog/mlops-tools-platforms-landscape).
 
 (s:task-deps)=
 ### Handling task dependencies


### PR DESCRIPTION
neptune.ai was acquired by OpenAI in December 2025 and the entire blog now 308-redirects to a press-release page, so the neptune.ai/blog link(s) below no longer lead to the referenced article(s).

This PR fixes 1 dead link in `doc/source/written/manual.md`, pointing the *MLOps tools landscape* reference to the Wayback Machine snapshot of the original article, pinned to the last working (HTTP 200) capture before the redirect took effect.